### PR TITLE
Make the secondary buttons more obvious

### DIFF
--- a/src/renderer/common/Button.svelte
+++ b/src/renderer/common/Button.svelte
@@ -50,11 +50,12 @@
 
     .btn.secondary {
         background-color: transparent;
-        border: 1px solid rgba(255, 255, 255, 0.05);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        background: rgba(255, 255, 255, 0.05);
         color: var(--text-normal);
     }
 
     .btn.secondary:hover {
-        border-color: rgba(255, 255, 255, 0.1);
+        border-color: rgba(255, 255, 255, 0.5);
     }
 </style>

--- a/src/renderer/common/Multiselect.svelte
+++ b/src/renderer/common/Multiselect.svelte
@@ -128,9 +128,8 @@
     }
 
     :global(.check-container input:checked + .check-item .btn) {
-        background-color: #fff;
-        border-color: transparent;
-        color: var(--accent);
+        border-color: #fff;
+        color: #fff;
     }
 
     :global(.check-container input:checked + .check-item .btn:active) {

--- a/src/renderer/common/Multiselect.svelte
+++ b/src/renderer/common/Multiselect.svelte
@@ -2,7 +2,7 @@
     import Button from "./Button.svelte";
     import {handleKeyboardToggle} from "../stores/controls.js";
     import {createEventDispatcher} from "svelte";
-    
+
     export let value;
     export let description;
     export let disabled = false;
@@ -56,14 +56,14 @@
     }
 
     .check-container:last-child {
-        margin: 0;  
+        margin: 0;
     }
 
     .check-item.disabled {
         background-color: var(--bg2-alt);
         cursor: not-allowed;
     }
-    
+
     .check-container input:checked + .check-item {
         background-color: var(--accent);
     }
@@ -128,11 +128,6 @@
     }
 
     :global(.check-container input:checked + .check-item .btn) {
-        border-color: #fff;
         color: #fff;
-    }
-
-    :global(.check-container input:checked + .check-item .btn:active) {
-        opacity: .8;
     }
 </style>


### PR DESCRIPTION
It was kind of hard to tell that they were buttons before.
I also de-emphasized the Browse button on selected rows to help suggest that most users don’t need to use it. (Maybe it should say something else like “Custom Path…”?)

<img width="662" alt="Screenshot_2021-05-14 13 59 29" src="https://user-images.githubusercontent.com/25517624/118310436-9ca76700-b4bc-11eb-95a7-334d68f685ee.png">
