### PR TITLE
Automatically select the most stable detected version

### DIFF
--- a/src/renderer/stores/installation.js
+++ b/src/renderer/stores/installation.js
@@ -4,7 +4,18 @@ import readwritable from "./types/readwritable";
 
 export const status = writable("");
 export const hasAgreed = writable(false);
-export const platforms = writable({stable: false, canary: false, ptb: false});
+
+const defaultPlatforms = {stable: false, canary: false, ptb: false};
+if (locations.stable) {
+    defaultPlatforms.stable = true;
+}
+else if (locations.ptb) {
+    defaultPlatforms.ptb = true;
+}
+else if (locations.canary) {
+    defaultPlatforms.canary = true;
+}
+export const platforms = writable(defaultPlatforms);
 export const paths = writable({stable: locations.stable, canary: locations.canary, ptb: locations.ptb});
 
 export const progress = readwritable(0);


### PR DESCRIPTION
An adapted implementation of my proposal in https://github.com/BetterDiscord/Installer/pull/128#issuecomment-847857633
Having it automatically select the most stable version helps counteract the fact that some people don't realize that the platforms page is a big multiselect. Also for it saves people who only have one version installed anyway which is detected correctly a click.