### PR TITLE
Automatically select platform after browsing

### DIFF
--- a/src/renderer/pages/Platforms.svelte
+++ b/src/renderer/pages/Platforms.svelte
@@ -13,14 +13,17 @@
     canGoBack.set(true);
     nextPage.set(`/${$action}`);
 
+    function updateInstallButtonState() {
+        if (Object.values($platforms).some(r => r)) canGoForward.set(true);
+        else canGoForward.set(false);
+    }
+
     function change({target}) {
         platforms.update(s => {
             s[target.value] = target.checked;
             return s;
         });
-
-        if (Object.values($platforms).some(r => r)) canGoForward.set(true);
-        else canGoForward.set(false);
+        updateInstallButtonState();
     }
 
     async function click(event) {
@@ -37,6 +40,11 @@
             obj[platform] = resourcesPath;
             return obj;
         });
+        platforms.update(obj => {
+            obj[platform] = Boolean(resourcesPath);
+            return obj;
+        });
+        updateInstallButtonState();
     }
 </script>
 


### PR DESCRIPTION
An implementation of my proposal in https://github.com/BetterDiscord/Installer/pull/128#issuecomment-847857633
Having it automatically select it is more intuitive because people tend to want to select a version that they specifically browse for. and it also helps counteract the fact that some people don't realize that the platforms page is a big multiselect.