### PR TITLE
Add skip asar download option for development

### DIFF
--- a/src/renderer/actions/install.js
+++ b/src/renderer/actions/install.js
@@ -111,11 +111,15 @@ export default async function(config) {
     log("✅ Directories created");
     progress.set(MAKE_DIR_PROGRESS);
     
-
-    lognewline("Downloading asar file");
-    const downloadErr = await downloadAsar();
-    if (downloadErr) return fail();
-    log("✅ Package downloaded");
+    if (!process.env.BD_SKIP_ASAR_DOWNLOAD) {
+        lognewline("Downloading asar file");
+        const downloadErr = await downloadAsar();
+        if (downloadErr) return fail();
+        log("✅ Package downloaded");
+    }
+    else {
+        lognewline("✅ Asar download skipped");
+    }
     progress.set(DOWNLOAD_PACKAGE_PROGRESS);
 
 


### PR DESCRIPTION
Added the ability to set  `BD_SKIP_ASAR_DOWNLOAD` environment variable to ... well I guess I don't need to explain what it does.

I was experimenting around with the installer a lot recently so I added this toggle to skip the asar download step during the installation. Thought it might be a useful thing to have in general for dev purposes or if an asar file was built from source.. so also dev purposes..