### PR TITLE
ProgramData version detection + Semver Version sorting

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6221,7 +6221,7 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.1.3, semver@^7.2.1, semver@^7.3.2:
+semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==


### PR DESCRIPTION
Fix proposal for #149
It's built on top of #139 so it's also a fix for #138. Which however still didn't explain why a lower version folder was sometimes detected, as there seemed to be a higher version folder detected.
This is also a bigger refactoring in general that also changes the validate functions which the original PR doesn't.

Tested to be working on Windows, but I did have to set it up the folders manually because discord installed itself in the normal appdata directory.