### PR TITLE
Automatic Update Checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dist:dir": "yarn dist --dir -c.compression=store -c.mac.identity=null"
   },
   "dependencies": {
+    "semver": "^7.3.5",
     "source-map-support": "^0.5.16"
   },
   "devDependencies": {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,6 +1,7 @@
-import {app, BrowserWindow, ipcMain} from "electron";
+import {app, BrowserWindow, shell} from "electron";
 import path from "path";
 import URL from "url";
+import updateInstaller from "./update_installer";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 app.name = "BetterDiscord";
@@ -54,7 +55,7 @@ function createMainWindow() {
 
     window.webContents.on("new-window", (e, url) => {
         e.preventDefault();
-        require("electron").shell.openExternal(url);
+        shell.openExternal(url);
     });
 
     return window;
@@ -73,6 +74,7 @@ app.on("activate", () => {
 });
 
 // create main BrowserWindow when electron is ready
-app.on("ready", () => {
+app.on("ready", async () => {
     mainWindow = createMainWindow();
+    if (!process.env.BD_SKIP_UPDATECHECK) updateInstaller();
 });

--- a/src/main/update_installer.js
+++ b/src/main/update_installer.js
@@ -1,0 +1,45 @@
+import {dialog, shell} from "electron";
+import phin from "phin";
+const semverGreaterThan = require("semver/functions/gt");
+const {version} = require("../../package.json");
+
+const getJSON = phin.defaults({
+    method: "GET",
+    parse: "json",
+    headers: {"User-Agent": "BetterDiscord Installer"},
+    followRedirects: true
+});
+
+export default async function () {
+    const downloadUrl = "https://api.github.com/repos/BetterDiscord/Installer/releases";
+    console.info(`Better Discord Installer ${version}`);
+
+    try {
+        const response = await getJSON(downloadUrl);
+        const latestRelease = response.body[0];
+        const latestVersion = latestRelease.tag_name;
+
+        if (semverGreaterThan(latestVersion, version)) {
+            console.info(`Found new release ${latestVersion}`);
+
+            const result = await dialog.showMessageBox({
+                title: "New Installer Version Available",
+                message: `A new version of the BetterDiscord installer is available. Click "Download" to download the newest version.`,
+                buttons: ["Download", "Later"],
+                defaultId: 0,
+                cancelId: 1
+            });
+
+            if (result.response === 0) {
+                await shell.openExternal(latestRelease.html_url);
+                process.exit(0);
+            }
+            
+        } else {
+            console.info(`The installer is up to date.`);
+        }
+    }
+    catch (err) {
+        console.error("Failed to check for updates.", err);
+    }
+}


### PR DESCRIPTION
Automatically checks if updates for the installer are available using the Github Releases API. Clicking on download will terminate the installer and open a the release page in the browser. It requires future release tags to be valid semver versions (optionally prefixed with `v.`). The current installer version is taken from the package.json. For testing purposes changing the version in the package json to something below 1.0.0 should trigger the prompt. The update checking is done asynchronously because I noticed a significantly increased startup time if it's done synchronously before the installer window starts.  

![image](https://user-images.githubusercontent.com/5641607/120399216-1a77c900-c32b-11eb-9aac-79f55229f645.png)

Implementation of the feature request from  #151
