### PR TITLE
prompt user to keep plugins when repairing

### DIFF
--- a/src/renderer/actions/repair.js
+++ b/src/renderer/actions/repair.js
@@ -40,6 +40,22 @@ async function deleteShims(paths) {
 const bdFolder = path.join(remote.app.getPath("appData"), "BetterDiscord");
 const bdDataFolder = path.join(bdFolder, "data");
 async function disableAllPlugins(channels) {
+    const confirmation = await remote.dialog.showMessageBox(remote.BrowserWindow.getFocusedWindow(), {
+        type: "question",
+        title: "Plugin Enabled",
+        message: "Would you like to keep your plugins enabled?",
+        noLink: true,
+        cancelId: 1,
+        buttons: ["Yes", "No"]
+    });
+
+    // If the user chooses to keep the plugins enabled, skip deleting plugins.json
+    if (confirmation.response === 0) {
+        log(`✅ Keeping plugins enabled`);
+        progress.set(DELETE_PLUGINS_JSON_PROGRESS);
+        return;
+    }
+
     const progressPerLoop = (DELETE_PLUGINS_JSON_PROGRESS - progress.value) / channels.length;
     for (const channel of channels) {
         const channelFolder = path.join(bdDataFolder, channel);
@@ -53,7 +69,6 @@ async function disableAllPlugins(channels) {
                 log(`✅ plugins.json does not exist`);
             }
             progress.set(progress.value + progressPerLoop);
-            
         }
         catch (err) {
             log(`❌ Failed to delete plugins.json: ${pluginsJson}`);


### PR DESCRIPTION
This pull request includes changes to enhance the user experience. The new change includes adding a user confirmation dialog to keep plugins enabled and ensuring consistent logging and progress updates.

![electron_20250216_8C5YAtDVdU](https://github.com/user-attachments/assets/e79fa9a4-3830-41be-bd5b-c6f85d3584ac)

User experience improvements:

* Added a confirmation dialog in the `disableAllPlugins` function to ask users if they want to keep their plugins enabled. If the user chooses to keep the plugins enabled, the deletion of `plugins.json` is skipped.