### PR TITLE
Build a Universal 2 macOS installer

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -94,6 +94,14 @@ jobs:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
 
+      - name: verify universal macOS binary
+        if: ${{ success() && matrix.os == 'macos-latest' }}
+        run: |
+          BINARY="dist/mac-universal/BetterDiscord.app/Contents/MacOS/BetterDiscord"
+          ARCHS="$(lipo -archs "$BINARY")"
+          echo "Architectures: $ARCHS"
+          [[ "$ARCHS" == *"x86_64"* && "$ARCHS" == *"arm64"* ]]
+
       - uses: actions/upload-artifact@v2
         if: ${{ success() && matrix.os == 'ubuntu-latest' }}
         with:

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
       "target": {
         "target": "zip",
         "arch": [
-          "x64"
+          "universal"
         ]
       }
     },

--- a/scripts/fixmac.js
+++ b/scripts/fixmac.js
@@ -12,15 +12,19 @@ const packageInfo = require(path.join(currentWorkingDirectory, "package.json"));
 const APP_NAME = packageInfo.build.productName;
 const APP_VERSION = process.argv[2] ? process.argv[2] : packageInfo.version;
 const APP_DIST_PATH = path.join(currentWorkingDirectory, "dist");
+const APP_OUTPUT_PATHS = ["mac-universal", "mac", "mac-arm64"]
+    .map(directory => path.join(APP_DIST_PATH, directory, `${APP_NAME}.app`));
 
 
 /* eslint-disable no-console */
 module.exports = function(buildResult) {
     if (!buildResult.artifactPaths.some(p => p.toLowerCase().endsWith("mac.zip"))) return console.log("No Mac build detected");
+    const appOutputPath = APP_OUTPUT_PATHS.find(fs.existsSync);
+    if (!appOutputPath) throw new Error(`Could not locate ${APP_NAME}.app in the macOS build output`);
     console.log("Zipping Started");
 
     execSync(
-        `ditto -c -k --sequesterRsrc --keepParent --zlibCompressionLevel 9 "${APP_DIST_PATH}/mac/${APP_NAME}.app" "${APP_DIST_PATH}/${APP_NAME}-${APP_VERSION}-mac.zip"`
+        `ditto -c -k --sequesterRsrc --keepParent --zlibCompressionLevel 9 "${appOutputPath}" "${APP_DIST_PATH}/${APP_NAME}-${APP_VERSION}-mac.zip"`
     );
 
     console.log("Zipping Completed");


### PR DESCRIPTION
## Summary

- build the macOS installer as a Universal 2 application instead of x64-only
- update the custom Mac re-zip hook to locate Electron Builder's `mac-universal` output while retaining the existing x64 and ARM64 fallbacks
- fail the release build if the main executable does not contain both `x86_64` and `arm64` slices

## Why

The currently published Mac installer contains only x86_64 Mach-O binaries, so it requires Rosetta 2 on Apple Silicon. Electron and Electron Builder already support Universal 2 packaging, and the existing lockfile already includes `@electron/universal`.

## Impact

The existing `BetterDiscord-Mac.zip` download becomes native on both Intel and Apple Silicon Macs without changing the release filename or download URL.

## Validation

- built the complete unsigned macOS ZIP with `CSC_IDENTITY_AUTO_DISCOVERY=false NODE_OPTIONS=--openssl-legacy-provider yarn dist`
- verified the main executable reports `x86_64 arm64` with `lipo -archs`
- unpacked the exact ZIP selected by the release workflow and verified all 21 Mach-O files contain both architecture slices
- passed package JSON parsing, `node --check scripts/fixmac.js`, targeted ESLint for the changed hook, and `git diff --check`

The repository-wide lint command remains blocked by the existing LF-versus-CRLF rule mismatch (1,378 pre-existing `linebreak-style` errors); the changed JavaScript hook passes targeted lint when that baseline line-ending rule is disabled.
