### PR TITLE
Build a Universal 2 macOS installer for Wails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,27 @@ jobs:
 
       - name: Build
         run: wails build -tags webkit2_41
+
+  build-macos:
+    name: Wails Build (macOS Universal 2)
+    runs-on: macos-latest
+    needs:
+      - frontend
+      - backend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Wails
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.11.0
+
+      - name: Build Universal 2 app
+        run: ./scripts/build-macos-universal.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build installer (macOS)
         if: ${{ matrix.os == 'macos-latest' }}
         shell: bash
-        run: wails build -ldflags="-X main.version=${{ steps.version.outputs.version }}"
+        run: ./scripts/build-macos-universal.sh -ldflags="-X main.version=${{ steps.version.outputs.version }}"
 
       - name: Upload Linux binary
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -96,7 +96,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: build-macos
-          path: build/bin/BetterDiscord-Installer.app
+          path: build/bin/BetterDiscord-Mac.zip
           if-no-files-found: error
 
   release:
@@ -128,5 +128,5 @@ jobs:
         run: |
           gh release create "${GITHUB_REF_NAME}" --draft --title "${GITHUB_REF_NAME}" --generate-notes \
             "release/BetterDiscord-Installer#Linux" \
-            "release/BetterDiscord-Installer.app#macOS" \
+            "release/BetterDiscord-Mac.zip#macOS (Universal 2)" \
             "release/BetterDiscord-Installer.exe#Windows"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This repository contains the source code for the BetterDiscord installer. The ap
 | Platform | Minimum Version | Support Status | Notes |
 | --- | --- | --- | --- |
 | Windows | Windows 10+ | ✅ | x64, ARM64, and x86 builds are available. |
-| macOS | macOS 11+ (Big Sur) | ✅ | x64 and ARM64 builds are available. |
+| macOS | macOS 11+ (Big Sur) | ✅ | A Universal 2 build supports x64 and ARM64. |
 | Linux | Ubuntu 20.04+ and Debian 11+, openSUSE 16.2+, Fedora Linux 32+ | ✅ | See Linux install support notes below. |
 
 Linux install support:

--- a/build/darwin/Info.plist
+++ b/build/darwin/Info.plist
@@ -6,7 +6,7 @@
         <key>CFBundleName</key>
         <string>{{.Info.ProductName}}</string>
         <key>CFBundleExecutable</key>
-        <string>{{.Name}}</string>
+        <string>BetterDiscord-Installer</string>
         <key>CFBundleIdentifier</key>
         <string>com.wails.{{.Name}}</string>
         <key>CFBundleVersion</key>

--- a/scripts/build-macos-universal.sh
+++ b/scripts/build-macos-universal.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "Universal macOS builds must run on macOS." >&2
+    exit 1
+fi
+
+for command in codesign ditto lipo; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "Required command not found: $command" >&2
+        exit 1
+    fi
+done
+
+WAILS_BIN="${WAILS_BIN:-wails}"
+if ! command -v "$WAILS_BIN" >/dev/null 2>&1; then
+    echo "Wails CLI not found: $WAILS_BIN" >&2
+    exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_PATH="$ROOT_DIR/build/bin/BetterDiscord Installer.app"
+EXECUTABLE_NAME="BetterDiscord-Installer"
+EXECUTABLE_PATH="$APP_PATH/Contents/MacOS/$EXECUTABLE_NAME"
+ZIP_PATH="$ROOT_DIR/build/bin/BetterDiscord-Mac.zip"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+cd "$ROOT_DIR"
+
+"$WAILS_BIN" build -platform darwin/amd64 -clean "$@"
+if [[ "$(lipo -archs "$EXECUTABLE_PATH")" != "x86_64" ]]; then
+    echo "Expected an x86_64 build at $EXECUTABLE_PATH" >&2
+    exit 1
+fi
+ditto "$APP_PATH" "$TEMP_DIR/amd64.app"
+
+"$WAILS_BIN" build -platform darwin/arm64 -s "$@"
+if [[ "$(lipo -archs "$EXECUTABLE_PATH")" != "arm64" ]]; then
+    echo "Expected an arm64 build at $EXECUTABLE_PATH" >&2
+    exit 1
+fi
+
+lipo -create \
+    "$TEMP_DIR/amd64.app/Contents/MacOS/$EXECUTABLE_NAME" \
+    "$EXECUTABLE_PATH" \
+    -output "$TEMP_DIR/$EXECUTABLE_NAME"
+mv "$TEMP_DIR/$EXECUTABLE_NAME" "$EXECUTABLE_PATH"
+chmod 755 "$EXECUTABLE_PATH"
+
+ARCHS="$(lipo -archs "$EXECUTABLE_PATH")"
+if [[ " $ARCHS " != *" x86_64 "* || " $ARCHS " != *" arm64 "* ]]; then
+    echo "Universal binary verification failed: $ARCHS" >&2
+    exit 1
+fi
+
+CODESIGN_IDENTITY="${CODESIGN_IDENTITY:--}"
+codesign --force --deep --sign "$CODESIGN_IDENTITY" "$APP_PATH"
+codesign --verify --deep --strict "$APP_PATH"
+
+rm -f "$ZIP_PATH"
+ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ZIP_PATH"
+
+echo "Created $ZIP_PATH ($ARCHS)"


### PR DESCRIPTION
## Summary

- add a macOS build script that compiles the Wails installer for `darwin/amd64` and `darwin/arm64`, merges the executables with `lipo`, signs the resulting app, and packages it as `BetterDiscord-Mac.zip`
- add a macOS Universal 2 CI job so both architecture slices are validated on pull requests
- update the release workflow to publish the Universal ZIP instead of trying to upload an app directory
- correct `CFBundleExecutable` so the generated plist names the executable Wails actually creates
- document that the macOS download is Universal 2

## Why

The Wails release workflow currently runs a plain `wails build`, which produces only the runner's native architecture. It also expects `build/bin/BetterDiscord-Installer.app`, while Wails creates `BetterDiscord Installer.app`, and the generated plist names `BetterDiscord Installer` even though the executable is `BetterDiscord-Installer`. As a result, the current app bundle and release upload path are inconsistent.

## Impact

The Wails branch produces one `BetterDiscord-Mac.zip` that runs natively on Intel and Apple Silicon Macs. The asset name matches the existing README download URL, and CI prevents either architecture slice from disappearing silently.

## Validation

- built both Wails targets locally with Wails v2.11.0 and merged them into one app
- unpacked the exact `BetterDiscord-Mac.zip` output and verified `lipo -archs` reports `x86_64 arm64`
- verified the executable named by `CFBundleExecutable` exists in the app bundle
- passed `codesign --verify --deep --strict` on the packaged app
- passed `go test ./...`
- passed frontend typecheck, ESLint, and production build
- passed shell syntax, workflow YAML parsing, and `git diff --check`
