### PR TITLE
fix: kill discord before writing betterdiscord.asar

### DIFF
--- a/discord/install.go
+++ b/discord/install.go
@@ -41,20 +41,20 @@ func (discord *DiscordInstall) InstallBD(options types.InstallOptions) error {
 	log.Println("✅ BetterDiscord prepared for install")
 	log.Println("")
 
+	// Discord locks app.asar and betterdiscord.asar while running, so it must be stopped before we can
+	// modify it. Capture the executable so it can be relaunched afterward.
+	exe, wasRunning, err := discord.stop()
+	if err != nil {
+		return err
+	}
+	log.Println("")
+
 	// Download and write betterdiscord.asar
 	log.Println("📥 Downloading BetterDiscord...")
 	if err := bd.Download(options.UseDevBuild); err != nil {
 		return err
 	}
 	log.Println("✅ BetterDiscord downloaded")
-	log.Println("")
-
-	// Discord locks app.asar while running, so it must be stopped before we can
-	// modify it. Capture the executable so it can be relaunched afterward.
-	exe, wasRunning, err := discord.stop()
-	if err != nil {
-		return err
-	}
 	log.Println("")
 
 	// Shadow app.asar with our loader


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link to the relevant issue if one exists. -->

fix for #426 

Closes Discord before attempting to write betterdiscord.asar. Not sure why this wasn't an issue in the Electron version, but Discord definitely has a handle on the file.

<img width="819" height="240" alt="firefox_1787989311_51584" src="https://github.com/user-attachments/assets/d75c101c-c7c2-4757-b5aa-26667aa8dc89" />

## Type of change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature / behavior change
- [ ] UI / component change (frontend)
- [ ] Backend / installer logic (Go)
- [ ] Build / release / CI
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Other: <!-- describe -->

## Testing

<!-- What did you manually verify? For UI changes, include a screenshot or recording. -->

- [ ] `bun run check` passes (frontend, from `frontend/`)
- [ ] `bun run lint` passes (frontend, from `frontend/`)
- [ ] `bun run test` passes (frontend, from `frontend/`)
- [x] `go test ./...` passes (backend)

## AI disclosure

<!-- See "AI-assisted contributions" in CONTRIBUTING.md for the full expectation. Check whichever applies. -->

- [x] I did not use AI assistance for this PR
- [ ] I used AI assistance and personally reviewed all generated output before submitting
- [ ] An AI agent generated part or all of this PR with minimal personal review. Details: <!-- describe what was generated and what (if anything) you reviewed -->
