### PR TITLE
Make close button after action is completed not open confirmation

### DIFF
--- a/frontend/src/routes/actions/perform/[action]/+page.svelte
+++ b/frontend/src/routes/actions/perform/[action]/+page.svelte
@@ -3,12 +3,11 @@
     import TextDisplay from "$lib/components/TextDisplay.svelte";
     import app from "$lib/stores/state.svelte";
     import {onDestroy, onMount} from "svelte";
-    import {EventsOn as listenFor, EventsOff as unlistenFor} from "@wails/runtime";
+    import {EventsOn as listenFor, EventsOff as unlistenFor, Quit as exit} from "@wails/runtime";
     import {goto} from "$app/navigation";
     import {Install as install, Repair as repair, Uninstall as uninstall} from "@api";
     import Page from "$lib/components/Page.svelte";
     import type {DiscordChannel} from "$lib/types";
-    import quit from "$lib/utils/quit";
 
 
     let status = $state("");
@@ -88,7 +87,7 @@
 </script>
 
 
-<Page title="{currentAction[0].toUpperCase()}{currentAction.slice(1)}" previous="/actions/configure/{app.action}" nextAction={quit} nextLabel="Quit" canGoNext={!active} canGoPrevious={!active}>
+<Page title="{currentAction[0].toUpperCase()}{currentAction.slice(1)}" previous="/actions/configure/{app.action}" nextAction={exit} nextLabel="Quit" canGoNext={!active} canGoPrevious={!active}>
     {#snippet icon()}
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
             {#if currentAction === "install"}


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link to the relevant issue if one exists. -->

This PR makes the "Quit" button after installing not open the system prompt to confirm whether the user wants to quit installation. I believe that this prompt is unintentional, since it is unnecessary and makes the install process a bit clunkier. The quit button is disabled mid-action so there is no risk of the user accidentally quitting while the install is still happening.

## Type of change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature / behavior change
- [ ] UI / component change (frontend)
- [ ] Backend / installer logic (Go)
- [ ] Build / release / CI
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Other: <!-- describe -->

## Testing

<!-- What did you manually verify? For UI changes, include a screenshot or recording. -->

- [x] `bun run check` passes (frontend, from `frontend/`)
- [x] `bun run lint` passes (frontend, from `frontend/`)
- [x] `bun run test` passes (frontend, from `frontend/`)
- [x] `go test ./...` passes (backend)

## AI disclosure

<!-- See "AI-assisted contributions" in CONTRIBUTING.md for the full expectation. Check whichever applies. -->

- [x] I did not use AI assistance for this PR
- [ ] I used AI assistance and personally reviewed all generated output before submitting
- [ ] An AI agent generated part or all of this PR with minimal personal review. Details: <!-- describe what was generated and what (if anything) you reviewed -->
